### PR TITLE
Make riot control compatible with other observable systems

### DIFF
--- a/riotcontrol.js
+++ b/riotcontrol.js
@@ -9,7 +9,7 @@ var RiotControl = {
   RiotControl[api] = function() {
     var args = [].slice.call(arguments);
     this._stores.forEach(function(el){
-      el[api].apply(null, args);
+      el[api].apply(el, args);
     });
   };
 });


### PR DESCRIPTION
Other observable patterns tend to store events state on the object instance, this simple fix allows to use them as an alternate observable system. For instance [Grapnel](https://github.com/EngineeringMode/Grapnel.js/).
