### PR TITLE
Add getStore function to RiotControl

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Created by .ignore support plugin (hsz.mobi)
+.idea

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 # Created by .ignore support plugin (hsz.mobi)
 .idea
+node_modules/

--- a/README.md
+++ b/README.md
@@ -86,14 +86,14 @@ RiotControl.trigger('todo_add', { title: self.text })
 Listen for event, and execute callback when it is triggered. This applies to all stores registered, so that you may receive the same event from multiple sources.
 
 ```javascript
-RiotControl.on(event, callback)
+var Store = RiotControl.getStore("store")
+Store.on(event, callback)
 
 // Example, inside Riot view (tag):
-RiotControl.on('todos_changed', function(items) {
+var TodoStore = RiotControl.getStore("TodoStore");
+TodoStore.on('todos_changed', function(items) {
     // Here we can get the todoStore anywhere in application.
-    var todoStore = RiotControl.getStore("TodoStore");
-    todoStore.onChange(items);
-    
+    TodoStore.onChange(items);
     self.items = items
     self.update()
 })
@@ -107,8 +107,8 @@ RiotControl.off(event)
 RiotControl.off(event, callback)
 ```
 
-Same as RiotControl.on(), executes once.
+Same as TodoStore.on(), executes once.
 
 ```javascript
-RiotControl.one(event, callback)
+TodoStore.one(event, callback)
 ```

--- a/README.md
+++ b/README.md
@@ -66,11 +66,11 @@ API
 Register the store in central dispatch, where store is a riot.observable(). Generally, all stores should be created and registered before the Riot app is mounted.
 
 ```javascript
-RiotControl.addStore(store) 
+RiotControl.addStore("store", store) 
 
 // Example, at start of application:
 var todoStore = new TodoStore() // Create a store instance.
-RiotControl.addStore(todoStore) // Register the store in central dispatch.
+RiotControl.addStore("TodoStore", todoStore) // Register the store in central dispatch.
 ```
 
 Trigger event on all stores registered in central dispatch. Essentially, a 'broadcast' version of Riot's el.trigger() API.
@@ -90,6 +90,10 @@ RiotControl.on(event, callback)
 
 // Example, inside Riot view (tag):
 RiotControl.on('todos_changed', function(items) {
+    // Here we can get the todoStore anywhere in application.
+    var todoStore = RiotControl.getStore("TodoStore");
+    todoStore.onChange(items);
+    
     self.items = items
     self.update()
 })

--- a/package.json
+++ b/package.json
@@ -19,10 +19,13 @@
     "riotjs",
     "flux"
   ],
-  "author": "Jim Sparkman",
-  "license": "MIT",
+  "author": "Sam Liu",
+  "license": "DWFYW",
   "bugs": {
     "url": "https://github.com/jimsparkman/RiotControl/issues"
   },
-  "homepage": "https://github.com/jimsparkman/RiotControl"
+  "homepage": "https://github.com/jimsparkman/RiotControl",
+  "dependencies": {
+    "lodash": "^3.10.1"
+  }
 }

--- a/riotcontrol.js
+++ b/riotcontrol.js
@@ -1,7 +1,15 @@
 var RiotControl = {
   _stores: [],
-  addStore: function(store) {
-    this._stores.push(store);
+  addStore: function(key, store) {
+    this._stores.push({"key": key, "store": store});
+  },
+  getStore: function(key) {
+    this._stores.forEach(function(el){
+      if (el.key === key) {
+        return el.store;
+      }
+    });
+    return null;
   },
   reset: function() {
     this._stores = [];
@@ -12,7 +20,7 @@ var RiotControl = {
   RiotControl[api] = function() {
     var args = [].slice.call(arguments);
     this._stores.forEach(function(el){
-      el[api].apply(el, args);
+      el[api].apply(el.store, args);
     });
   };
 });

--- a/riotcontrol.js
+++ b/riotcontrol.js
@@ -4,12 +4,13 @@ var RiotControl = {
     this._stores.push({"key": key, "store": store});
   },
   getStore: function(key) {
+    var store = null;
     this._stores.forEach(function(el){
       if (el.key === key) {
-        return el.store;
+        store = el.store;
       }
     });
-    return null;
+    return store;
   },
   reset: function() {
     this._stores = [];
@@ -20,7 +21,7 @@ var RiotControl = {
   RiotControl[api] = function() {
     var args = [].slice.call(arguments);
     this._stores.forEach(function(el){
-      el[api].apply(el.store, args);
+      el.store[api].apply(el.store, args);
     });
   };
 });

--- a/riotcontrol.js
+++ b/riotcontrol.js
@@ -1,27 +1,22 @@
+var _ = require('lodash');
 var RiotControl = {
-  _stores: [],
-  addStore: function(key, store) {
-    this._stores.push({"key": key, "store": store});
+  _stores: {},
+  setStore: function(key, store) {
+    this._stores[key] = store;
   },
   getStore: function(key) {
-    var store = null;
-    this._stores.forEach(function(el){
-      if (el.key === key) {
-        store = el.store;
-      }
-    });
-    return store;
+    return this._stores[key]
   },
   reset: function() {
-    this._stores = [];
+    this._stores = {};
   }
 };
 
 ['on','one','off','trigger'].forEach(function(api){
   RiotControl[api] = function() {
     var args = [].slice.call(arguments);
-    this._stores.forEach(function(el){
-      el.store[api].apply(el.store, args);
+    _.values(this._stores).forEach(function(el){
+      el[api].apply(el, args);
     });
   };
 });


### PR DESCRIPTION
Sometime we need to get store from RiotControl at another page/view, what we did it now is like this:

```
            RiotControl._stores[0].load();
```

That will be better if we can use it like this:

```
            RiotControl.getStore("TodoStore").load();
```
